### PR TITLE
Load package config from confign.tiny.vim

### DIFF
--- a/config/confign.vim
+++ b/config/confign.vim
@@ -8,37 +8,8 @@
 " vim-plug conf "
 " ------------- "
 
-call plug#begin('~/.config/nvim/plugged')
-Plug 'Shougo/denite.nvim'
-Plug 'Shougo/vimproc.vim', {'do': 'make'}
-Plug 'Shougo/deoplete.nvim', { 'do': ':UpdateRemotePlugins' }
-Plug 'autozimu/LanguageClient-neovim', {'branch': 'next', 'do': 'bash install.sh'}
-Plug 'Shougo/neosnippet.vim'
-Plug 'Shougo/neosnippet-snippets'
-Plug 'scrooloose/nerdtree'
-Plug 'tiagofumo/vim-nerdtree-syntax-highlight'
-Plug 'junegunn/seoul256.vim'
-Plug 'vim-airline/vim-airline'
-Plug 'vim-airline/vim-airline-themes'
-Plug 'godlygeek/tabular'
-Plug 'majutsushi/tagbar'
-Plug 'osyo-manga/vim-anzu'
-Plug 'tomtom/tcomment_vim'
-Plug 'bronson/vim-trailing-whitespace'
-Plug 'nathanaelkane/vim-indent-guides'
-Plug 'scrooloose/syntastic'
-Plug 'haya14busa/incsearch.vim'
-Plug 't9md/vim-quickhl'
-Plug 'osyo-manga/vim-over'
-Plug 'sheerun/vim-polyglot'
-Plug 'lervag/vimtex'
-Plug 'octol/vim-cpp-enhanced-highlight'
-Plug 'vim-ruby/vim-ruby'
-Plug 'tpope/vim-rails'
-Plug 'rust-lang/rust.vim'
-Plug 'hynek/vim-python-pep8-indent'
-Plug 'tell-k/vim-autopep8'
-call plug#end()
+" load packages
+source $HOME/.dotfiles/config/confign.tiny.vim
 
 
 " Plug 'Shougo/denite.nvim'


### PR DESCRIPTION
There are the same configs in `confign.tiny.vim` and `confign.vim`.
In this PR, I remove the duplicated section from `confign.vim`.
Then `confign.vim` load the package config from `confign.tiny.vim`.