### PR TITLE
Modify the way to check if it should initialize ssh-agent

### DIFF
--- a/config/config.zsh
+++ b/config/config.zsh
@@ -70,7 +70,7 @@ case ${OSTYPE} in
       export MECAB_PATH=`mecab-config --libs-only-L`/libmecab.so.2
     fi
 
-    if [ -z $SSH_CLIENT ]; then
+    if [ -z $SSH_AGENT_PID ]; then
       echo 'Initializing ssh-agent...'
       eval `ssh-agent` &> /dev/null
     fi


### PR DESCRIPTION
Instead of SSH_CLIENT, I use SSH_AGENT_PID to check if
I have to initialize ssh-agent