### PR TITLE
Use python installed globally in NeoVim

### DIFF
--- a/nvim/config.d/init.vim
+++ b/nvim/config.d/init.vim
@@ -9,6 +9,9 @@
 " ---------------------
 "
 
+"" use python3 installed globally
+let g:python3_host_prog=$SYSTEM_PYTHON_PATH
+
 "" load basic vim configuration
 source $HOME/.dotfiles/vim/config.d/vimrc
 

--- a/zsh/config.d/zshrc
+++ b/zsh/config.d/zshrc
@@ -23,6 +23,12 @@ export PYENV_ROOT=$HOME/.pyenv
 export PATH="$PYENV_ROOT/bin:$PATH"
 export PYTHONDONTWRITEBYTECODE=1
 
+# path to system python for NeoVim
+if ! [[ -v SYSTEM_PYTHON_PATH ]]; then
+  export SYSTEM_PYTHON_PATH=`which python3`
+fi
+
+
 
 # generals
 case ${OSTYPE} in


### PR DESCRIPTION
This PR makes NeoVim uses Python globally installed even if venv is activated.