### PR TITLE
Update package of vscode

### DIFF
--- a/package/Brewfile.cask
+++ b/package/Brewfile.cask
@@ -10,5 +10,6 @@ cask 'mendeley'
 cask 'slack'
 
 cask 'microsoft-office'
+cask 'visual-studio-code'
 
 cask 'mactex'

--- a/vscode/bin/setup.sh
+++ b/vscode/bin/setup.sh
@@ -4,13 +4,13 @@
 echo 'Deploy settings'
 LINK_FILE=settings.json
 
-unlink ~/Library/Application\ Support/Code\ -\ Insiders/User/$LINK_FILE&>/dev/null
-ln -sf $PWD/vscode/config.d/$LINK_FILE ~/Library/Application\ Support/Code\ -\ Insiders/User/$LINK_FILE
+unlink ~/Library/Application\ Support/Code/User/$LINK_FILE&>/dev/null
+ln -sf $PWD/vscode/config.d/$LINK_FILE ~/Library/Application\ Support/Code/User/$LINK_FILE
 
 
 echo 'Install extensions'
 EXTENSIONS=$(cat ./vscode/config.d/extensions.list)
 
 for extension in ${EXTENSIONS[@]}; do \
-  code-insiders --install-extension $extension; \
+  code --install-extension $extension; \
 done

--- a/vscode/config.d/extensions.list
+++ b/vscode/config.d/extensions.list
@@ -1,5 +1,6 @@
+castwide.solargraph
+Hridoy.rails-snippets
 James-Yu.latex-workshop
-mauve.terraform
 ms-python.python
 ms-vscode-remote.remote-containers
 ms-vscode-remote.remote-ssh
@@ -7,4 +8,9 @@ ms-vscode-remote.remote-ssh-edit
 ms-vscode-remote.remote-ssh-explorer
 ms-vscode-remote.remote-wsl
 ms-vscode-remote.vscode-remote-extensionpack
+ms-vscode.cpptools
 njpwerner.autodocstring
+oderwat.indent-rainbow
+PeterJausovec.vscode-docker
+rebornix.ruby
+vayan.haml

--- a/vscode/config.d/settings.json
+++ b/vscode/config.d/settings.json
@@ -3,7 +3,7 @@
     "C_Cpp.default.cppStandard": "c++17",
     "C_Cpp.default.cStandard": "c11",
     "latex-workshop.view.pdf.viewer": "tab",
-    "window.zoomLevel": 1,
+    "window.zoomLevel": -1,
     "python.venvPath": "./venv",
     "python.testing.nosetestsEnabled": true,
     "python.linting.pylamaEnabled": true,

--- a/vscode/config.d/settings.json
+++ b/vscode/config.d/settings.json
@@ -3,12 +3,15 @@
     "C_Cpp.default.cppStandard": "c++17",
     "C_Cpp.default.cStandard": "c11",
     "latex-workshop.view.pdf.viewer": "tab",
-    "window.zoomLevel": -2,
+    "window.zoomLevel": 1,
     "python.venvPath": "./venv",
     "python.testing.nosetestsEnabled": true,
     "python.linting.pylamaEnabled": true,
     "python.linting.pydocstyleEnabled": true,
     "python.linting.pep8Enabled": true,
     "files.eol": "\n",
-    "python.linting.flake8Enabled": true
+    "python.linting.flake8Enabled": true,
+    "solargraph.formatting": true,
+    "solargraph.diagnostics": true,
+    "solargraph.folding": false
 }


### PR DESCRIPTION
https://code.visualstudio.com/updates/v1_35#_remote-development-preview

Visual Studio Code v1.35 provides the feature of Remote development.
According to this release, I stop using vscode insiders and start using vscode stable.