### PR TITLE
[BUGFIX] Stop using ZPLUG_HOME to set destination of zplug

### DIFF
--- a/zsh/bin/setup.sh
+++ b/zsh/bin/setup.sh
@@ -1,5 +1,5 @@
 
 
-git clone https://github.com/zplug/zplug $ZPLUG_HOME
+git clone https://github.com/zplug/zplug $HOME/.config/zplug
 
 ln -s `pwd`/zsh/config.d/zshrc $HOME/.zshrc


### PR DESCRIPTION
When it runs a startup script, $ZPLUG_HOMME would not be set.
Then, zplug will be installed to `$HOME/.dotfiles` and solve this problem.