### PR TITLE
Make brew optional

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,8 @@ build_brew:
 	$(BREW_COMMAND)
 brew_bundle:
 	brew bundle --file=package/Brewfile
+brew_bundle_opt:
+	brew bundle --file=package/Brewfile.optional
 
 clean:
 	@echo 'remove symbolic links'
@@ -74,6 +76,7 @@ done:
 	@echo "  please run $(RED)make brew_bundle$(NOCOLOR)."
 	@echo "  Please run $(RED)make build_brew$(NOCOLOR) before"
 	@echo "  if you have not installed brew yet"
+	@echo "  $(RED)make brew_bundle_opt$(NOCOLOR) installs optional packages"
 	@echo ""
 	@echo "---"
 	@echo "### Python"

--- a/package/Brewfile
+++ b/package/Brewfile
@@ -7,12 +7,3 @@ brew 'tmux'
 
 brew 'wget'
 brew 'zsh'
-
-brew 'coreutils'
-brew 'ghq'
-brew 'htop'
-brew 'tree'
-
-brew 'fzf'
-brew 'the_silver_searcher'
-brew 'bat'

--- a/package/Brewfile.optional
+++ b/package/Brewfile.optional
@@ -1,0 +1,8 @@
+
+brew 'coreutils'
+brew 'htop'
+brew 'tree'
+brew 'fzf'
+brew 'the_silver_searcher'
+brew 'bat'
+brew 'ghq'


### PR DESCRIPTION
There are some packages which are not required as minimum requirements.
And installing them takes a long time.
So, for CI, I skip to install them and install only packages which are required for
minimum dotfile workload.