### PR TITLE
Add python snippet to disable specific warning

### DIFF
--- a/snippets/python/pylint_click.snippets
+++ b/snippets/python/pylint_click.snippets
@@ -1,0 +1,3 @@
+snippet pylint_click
+# pylint: disable=no-value-for-parameter
+endsnippet


### PR DESCRIPTION
@click.command edits a signature of a method.
`pylint` doesn't consider this since it doesn't run the code.
This PR introduces a workaround to suppress a warning.

ref. https://stackoverflow.com/questions/49680191/click-and-pylint