### PR TITLE
Remove venv_init

### DIFF
--- a/bin/venv_init
+++ b/bin/venv_init
@@ -1,3 +1,0 @@
-
-
-pip3 install -r $HOME/.dotfiles/package/requirements.txt

--- a/package/requirements.txt
+++ b/package/requirements.txt
@@ -1,9 +1,0 @@
-
-python-language-server
-
-flake8
-autopep8
-black
-isort
-
-pytest


### PR DESCRIPTION
Currently, I stopped using `venv` directly and started using `pipenv`.