### PR TITLE
Remove incsearch.vim

### DIFF
--- a/nvim/config.d/init.vim
+++ b/nvim/config.d/init.vim
@@ -90,6 +90,3 @@ set statusline=%anzu#search_status()
 
 " Plug 'vim-airline/vim-airline'
 let g:airline_theme= 'deus'
-
-" Plug 'haya14busa/incsearch.vim'
-map / <Plug>(incsearch-forward)

--- a/nvim/config.d/tiny.init.vim
+++ b/nvim/config.d/tiny.init.vim
@@ -18,7 +18,6 @@ Plug 'scrooloose/nerdtree'
 Plug 'godlygeek/tabular'
 
 " rich search
-Plug 'haya14busa/incsearch.vim'
 Plug 'osyo-manga/vim-anzu'
 
 " language supports


### PR DESCRIPTION
Functionalities of incsearch.vim are now available on Vim. :tada:

ref. https://medium.com/@haya14busa/incsearch-vim-is-dead-long-live-incsearch-2b7070d55250