### PR TITLE
Remove vim-ruby

### DIFF
--- a/nvim/config.d/tiny.init.vim
+++ b/nvim/config.d/tiny.init.vim
@@ -22,9 +22,8 @@ Plug 'osyo-manga/vim-anzu'
 
 " language supports
 Plug 'sheerun/vim-polyglot'
-Plug 'vim-ruby/vim-ruby'
-Plug 'tpope/vim-rails'
 Plug 'google/vim-jsonnet'
+Plug 'tpope/vim-rails'
 
 " colorscheme
 Plug 'vim-scripts/ScrollColors'


### PR DESCRIPTION
I remove `vim-ruby` from the vim-plug installing list because `vim-polyglot` include it.