### PR TITLE
Add dummy jsonnet path

### DIFF
--- a/vscode/config.d/settings.json
+++ b/vscode/config.d/settings.json
@@ -30,6 +30,7 @@
   "go.formatTool": "goimports",
   "go.useLanguageServer": true,
   "java.configuration.checkProjectSettingsExclusions": false,
+  "jsonnet.executablePath": "dummyjsonnet",
   "markdown.preview.fontSize": 13,
   "python.formatting.provider": "black",
   "python.jediEnabled": false,
@@ -86,6 +87,6 @@
   "workbench.editor.showTabs": true,
   "workbench.iconTheme": "material-icon-theme",
   "workbench.sideBar.location": "left",
-  "workbench.startupEditor": "newUntitledFile",
-  "workbench.tree.indent": 15
+  "workbench.tree.indent": 15,
+  "workbench.startupEditor": "welcomePageInEmptyWorkbench"
 }


### PR DESCRIPTION
Jsonnet plugin checks the values of `std.extVar` when the file is saved.
If you don't want to put ext vars in your vscode setting, jsonnet should not be executed.
(Of course, you could not use preview features.)