### PR TITLE
debug: install homebrew

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,18 @@
+name: "test"
+
+on: [push]
+
+jobs:
+  check_pr:
+
+    strategy:
+      matrix:
+        os: [macos-latest]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v4
+      - run: |
+          /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+          brew doctor

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,4 +15,4 @@ jobs:
       - uses: actions/checkout@v4
       - run: |
           /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-          brew doctor
+          brew install --cask font-jetbrains-mono


### PR DESCRIPTION
```sh
> brew info font-jetbrains-mono
Warning: Formula homebrew/cask-fonts/font-jetbrains-mono was renamed to homebrew/cask/font-jetbrains-mono.
==> font-jetbrains-mono: 2.304
https://www.jetbrains.com/lp/mono
Installed
/opt/homebrew/Caskroom/font-jetbrains-mono/2.304 (52 files, 5.7MB)
From: https://github.com/Homebrew/homebrew-cask/blob/HEAD/Casks/font/font-j/font-jetbrains-mono.rb
==> Name
JetBrains Mono
==> Description
Typeface made for developers
==> Artifacts
fonts/ttf/JetBrainsMonoNL-Bold.ttf (Font)
fonts/ttf/JetBrainsMonoNL-BoldItalic.ttf (Font)
fonts/ttf/JetBrainsMonoNL-ExtraBold.ttf (Font)
fonts/ttf/JetBrainsMonoNL-ExtraBoldItalic.ttf (Font)
fonts/ttf/JetBrainsMonoNL-ExtraLight.ttf (Font)
fonts/ttf/JetBrainsMonoNL-ExtraLightItalic.ttf (Font)
fonts/ttf/JetBrainsMonoNL-Italic.ttf (Font)
fonts/ttf/JetBrainsMonoNL-Light.ttf (Font)
fonts/ttf/JetBrainsMonoNL-LightItalic.ttf (Font)
fonts/ttf/JetBrainsMonoNL-Medium.ttf (Font)
fonts/ttf/JetBrainsMonoNL-MediumItalic.ttf (Font)
fonts/ttf/JetBrainsMonoNL-Regular.ttf (Font)
fonts/ttf/JetBrainsMonoNL-SemiBold.ttf (Font)
fonts/ttf/JetBrainsMonoNL-SemiBoldItalic.ttf (Font)
fonts/ttf/JetBrainsMonoNL-Thin.ttf (Font)
fonts/ttf/JetBrainsMonoNL-ThinItalic.ttf (Font)
fonts/variable/JetBrainsMono-Italic[wght].ttf (Font)
fonts/variable/JetBrainsMono[wght].ttf (Font)
==> Analytics
install: 677 (30 days), 677 (90 days), 677 (365 days)
```