### PR TITLE
misc(zsh): kubectl-toggle_ctx as outside dependency

### DIFF
--- a/bin/kubectl-toggle_ctx
+++ b/bin/kubectl-toggle_ctx
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-
-if test -f $HOME/.kubectl-hide-current-ctx; then
-  rm $HOME/.kubectl-hide-current-ctx
-else
-  touch $HOME/.kubectl-hide-current-ctx
-fi

--- a/zsh/config.d/zshrc
+++ b/zsh/config.d/zshrc
@@ -126,7 +126,7 @@ export PYTHONSYSTEMPATH=$(which python3)
 # NOTE; Utilities
 
 function current_context () {
-  if test -f ~/.kubectl-hide-current-ctx; then
+  if test -f $XDG_CONFIG_HOME/kubectl-toggle-ctx/hide; then
     return
   fi
 


### PR DESCRIPTION
Extracted to https://github.com/himkt/kubectl-toggle_ctx.