### PR TITLE
chore(ghostty): disable ligature and map shift+enter to create newline

### DIFF
--- a/ghostty/config.d/config
+++ b/ghostty/config.d/config
@@ -14,5 +14,6 @@ background-blur-radius = 20
 
 # font config
 font-family  = Jetbrains Mono
-font-size    = 16
-font-feature = -calt
+font-size    = 15
+font-feature = -calt, -liga, -dlig
+keybind = shift+enter=text:\n


### PR DESCRIPTION
🔗. https://ghostty.org/docs/config/reference#font-feature