### PR TITLE
chore: Task was renamed to Agent

### DIFF
--- a/home/modules/claude-code/files/rules/source-navigation.md
+++ b/home/modules/claude-code/files/rules/source-navigation.md
@@ -2,5 +2,5 @@
 
 - NEVER use `ls` or `tree` via Bash. These are denied in settings.json
 - Use Glob tool for file/directory listing and pattern-based search
-- Use Explore agent (Task tool with subagent_type=Explore) for broader codebase navigation
+- Use Explore agent (Agent tool with subagent_type=Explore) for broader codebase navigation
 - Use Read tool to inspect directory contents when needed

--- a/home/modules/claude-code/files/skills/design-doc-create/SKILL.md
+++ b/home/modules/claude-code/files/skills/design-doc-create/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: design-doc-create
 description: Create a new design document using the design-doc-creator agent. Use when user wants to create a specification, implementation plan, or technical document. Teammates must always load skills using the Skill tool, not by reading skill files directly. Do NOT use EnterPlanMode — always invoke this skill instead.
-allowed-tools: Read, Write, Edit, Glob, Grep, Task, WebSearch, WebFetch
+allowed-tools: Read, Write, Edit, Glob, Grep, Agent, WebSearch, WebFetch
 ---
 
 # Design Doc Create (Agent Teams Edition)

--- a/home/modules/claude-code/files/skills/design-doc-execute/SKILL.md
+++ b/home/modules/claude-code/files/skills/design-doc-execute/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: design-doc-execute
 description: Implement features based on a design document with automatic validation and fixing. Use when the user asks to implement or execute a design document. Takes document path as argument. Teammates must always load skills using the Skill tool, not by reading skill files directly. Do NOT implement a design document by reading it and coding manually — always invoke this skill instead.
-allowed-tools: Read, Write, Edit, Glob, Grep, Bash, Task, WebSearch, WebFetch
+allowed-tools: Read, Write, Edit, Glob, Grep, Bash, Agent, WebSearch, WebFetch
 ---
 
 # Design Doc Execute (Agent Teams Edition)

--- a/home/modules/claude-code/files/skills/design-doc-interview/SKILL.md
+++ b/home/modules/claude-code/files/skills/design-doc-interview/SKILL.md
@@ -7,22 +7,22 @@ description: >-
   Use after /design-doc-create and before /design-doc-execute.
   Takes document path as argument.
   Do NOT use this to create or execute design documents — use the dedicated skills instead.
-allowed-tools: Read, Write, Edit, Glob, Grep, AskUserQuestion, Task
+allowed-tools: Read, Write, Edit, Glob, Grep, AskUserQuestion, Agent
 ---
 
 # Design Doc Interview
 
-Validate a design document through structured, fine-grained Q&A across multiple sessions. The Interviewer (main Claude) drives the conversation, while an Analyzer subagent (Explore type via Task tool) handles document analysis and question generation. Discrepancies produce inline `COMMENT(claude)` annotations. Multi-session splitting prevents context compaction for large interviews.
+Validate a design document through structured, fine-grained Q&A across multiple sessions. The Interviewer (main Claude) drives the conversation, while an Analyzer subagent (Explore type via Agent tool) handles document analysis and question generation. Discrepancies produce inline `COMMENT(claude)` annotations. Multi-session splitting prevents context compaction for large interviews.
 
 | Aspect | Detail |
 |:--|:--|
 | **Interviewer** | Main Claude — orchestrates session, drives Q&A, annotates findings |
-| **Analyzer** | Subagent (Explore type via Task tool) — reads document, generates question list |
+| **Analyzer** | Subagent (Explore type via Agent tool) — reads document, generates question list |
 | **Input** | Design document path (required argument via `$ARGUMENTS`) |
 | **Output** | Inline `# COMMENT(claude)` annotations, progress update, session report |
 | **Interaction** | ALL Analyzer questions asked via `AskUserQuestion` (4 per call, minimized rounds) |
 | **Scale** | All Analyzer questions asked — up to 100 across multiple sessions |
-| **Allowed tools** | Read, Write, Edit, Glob, Grep, AskUserQuestion, Task |
+| **Allowed tools** | Read, Write, Edit, Glob, Grep, AskUserQuestion, Agent |
 
 ## Context Management Strategy
 
@@ -66,7 +66,7 @@ Progress is tracked via `question.md` in the design document's directory (e.g., 
 
 ### Step 2: Analyze Document (Subagent)
 
-Spawn an Analyzer subagent (Explore type via Task tool) with:
+Spawn an Analyzer subagent (Explore type via Agent tool) with:
 
 - The design document path
 - The list of already-reviewed sections (if any)

--- a/home/modules/claude-code/files/skills/research-presentation/SKILL.md
+++ b/home/modules/claude-code/files/skills/research-presentation/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: research-presentation
 description: Create a Slidev presentation and reading transcript from an existing research report folder. Reads report.md and researcher files for context, creates slides using /my-slidev skill and a reading transcript. Takes folder path as argument (e.g., design-docs/topic-name). Do NOT use for research — use /research-report for that.
-allowed-tools: Read, Write, Edit, Glob, Grep, Task
+allowed-tools: Read, Write, Edit, Glob, Grep, Agent
 ---
 
 # Research Presentation

--- a/home/modules/claude-code/files/skills/research-report/SKILL.md
+++ b/home/modules/claude-code/files/skills/research-report/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: research-report
 description: Create a comprehensive research report with folder-based output using agent teams. Researchers write findings to individual files, Manager compiles report.md, Director reviews. Output goes to design-docs/{topic-slug}/. After report approval, offers to chain into /research-presentation for slides and transcript. Teammates must always load skills using the Skill tool, not by reading skill files directly. Requires CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS enabled. Do NOT do a quick web search and summarize — invoke this skill for thorough, multi-source research.
-allowed-tools: Read, Write, Edit, Glob, Grep, WebSearch, WebFetch, Task
+allowed-tools: Read, Write, Edit, Glob, Grep, WebSearch, WebFetch, Agent
 ---
 
 # Research Report (Agent Teams Edition)


### PR DESCRIPTION
> The tool name was renamed from "Task" to "Agent" in Claude Code v2.1.63. Current SDK releases emit "Agent" in tool_use blocks but still use "Task" in the system:init tools list and in result.permission_denials[].tool_name. Checking both values in block.name ensures compatibility across SDK versions.

🔗. https://platform.claude.com/docs/en/agent-sdk/subagents#detecting-subagent-invocation